### PR TITLE
Fix download URL on PyPI

### DIFF
--- a/download.html
+++ b/download.html
@@ -1,4 +1,3 @@
-
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
   "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 
@@ -104,7 +103,7 @@
 <h1>Download<a class="headerlink" href="#download" title="Permalink to this headline">¶</a></h1>
 <div class="section" id="stable-release">
 <h2>Stable release<a class="headerlink" href="#stable-release" title="Permalink to this headline">¶</a></h2>
-<p>The latest stable release is available from the <a class="reference external" href="http://pypi.python.org/pypi/skimage">Python packaging
+<p>The latest stable release is available from the <a class="reference external" href="http://pypi.python.org/pypi/scikits-image">Python packaging
 index</a>.  It is also
 included as part of the Enthought Python Distribution (EPD) and
 Python(x,y).</p>


### PR DESCRIPTION
Is this change intentional? Maybe it would be better to keep scikits.image (or use scikits-image) as package name for PyPI?
