### PR TITLE
Change release announcement dates to ISO 8601

### DIFF
--- a/index.html
+++ b/index.html
@@ -124,13 +124,13 @@ http://dx.doi.org/10.7717/peerj.453
 <div class="section" id="announcements">
 <h1>Announcements<a class="headerlink" href="#announcements" title="Permalink to this headline">¶</a></h1>
 <ul class="simple">
-<li><strong>Release!</strong> Version 0.12.0 06/03/2016</li>
-<li><strong>Release!</strong> Version 0.11.0 04/03/2015</li>
-<li><strong>Release!</strong> Version 0.10.0 27/05/2014</li>
+<li><strong>Release!</strong> Version 0.12.0 2016-03-06</li>
+<li><strong>Release!</strong> Version 0.11.0 2015-03-04</li>
+<li><strong>Release!</strong> Version 0.10.0 2014-05-27</li>
 <li>Pre-print of the scikit-image paper: <a class="reference external" href="https://peerj.com/preprints/336/">https://peerj.com/preprints/336/</a></li>
-<li><strong>Release!</strong> Version 0.9.0 19/10/2013</li>
-<li><strong>Release!</strong> Version 0.8.0 04/03/2013</li>
-<li><strong>Release!</strong> Version 0.7.0 30/09/2012</li>
+<li><strong>Release!</strong> Version 0.9.0 2013-10-19</li>
+<li><strong>Release!</strong> Version 0.8.0 2013-03-04</li>
+<li><strong>Release!</strong> Version 0.7.0 2012-09-30</li>
 <li><strong>EuroSciPy Sprint</strong>, Belgium, August 2012</li>
 <li><strong>SciPy 2012 Sprint</strong>, Austin, July 2012</li>
 </ul>


### PR DESCRIPTION
As scikit is an international and scientific project the international / scientific standard for dates should be used.